### PR TITLE
Only use name in field options if not empty

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -289,7 +289,9 @@ func (g *Generator) getName(d desc.Descriptor) (name string) {
 	if ext, err := proto.GetExtension(d.GetOptions(), yara.E_MessageOptions); err == nil {
 		name = ext.(*yara.MessageOptions).GetName()
 	} else if ext, err := proto.GetExtension(d.GetOptions(), yara.E_FieldOptions); err == nil {
-		name = ext.(*yara.FieldOptions).GetName()
+		if ext.(*yara.FieldOptions).GetName() != "" {
+			name = ext.(*yara.FieldOptions).GetName()
+		}
 	} else if ext, err := proto.GetExtension(d.GetOptions(), yara.E_EnumOptions); err == nil {
 		name = ext.(*yara.EnumOptions).GetName()
 	}

--- a/pb/yara.proto
+++ b/pb/yara.proto
@@ -10,7 +10,9 @@ message ModuleOptions {
 }
 
 message FieldOptions {
+  // Name of the field in YARA rules. Ignored if empty.
   string name = 1;
+
   bool ignore = 2;
 }
 


### PR DESCRIPTION
It prevents setting an empty name to the field in YARA rules if other field options are set but the name is not provided.